### PR TITLE
fix scenario error code and typos

### DIFF
--- a/code/Test_definitions/device-swap-check.feature
+++ b/code/Test_definitions/device-swap-check.feature
@@ -18,7 +18,7 @@ Feature: CAMARA Device Swap API, 0.2.0 - Operation checkDeviceSwap
 
     # This first scenario serves as a minimum, not testing any specific verificationResult
     @check_device_swap_1_generic_success_scenario
-    Scenario: Common validations for any sucess scenario
+    Scenario: Common validations for any success scenario
         Given a valid phone number identified by the token or provided in the request body
         When the request "checkDeviceSwap" is sent
         Then the response status code is 200
@@ -54,7 +54,7 @@ Feature: CAMARA Device Swap API, 0.2.0 - Operation checkDeviceSwap
     @check_device_swap_4_more_than_240_hours
     Scenario: Check that the response shows that the device has not been swapped when "maxAge" is not set and the last swap was more than 240 (default) hours ago
         Given a valid phone number identified by the token or provided in the request body
-        And the request body property "maxAge" is not setted
+        And the request body property "maxAge" is not set
         And the device has been swapped more than 240 hours ago
         When the request "checkDeviceSwap" is sent
         Then the response status code is 200
@@ -105,7 +105,7 @@ Feature: CAMARA Device Swap API, 0.2.0 - Operation checkDeviceSwap
         When the HTTP "POST" request is sent
         Then the response status code is 422
         And the response property "$.status" is 422
-        And the response property "$.code" is "NOT_SUPPORTED"
+        And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
         And the response property "$.message" contains a user friendly text
 
     # Test cases related to the device identifier

--- a/code/Test_definitions/device-swap-retrieve-date.feature
+++ b/code/Test_definitions/device-swap-retrieve-date.feature
@@ -17,7 +17,7 @@ Feature: CAMARA Device Swap API, 0.2.0 - Operation retrieveDeviceSwapDate
 
     # This first scenario serves as a minimum, not testing any specific verificationResult
     @retrieve_device_swap_date_1_generic_success_scenario
-    Scenario: Common validations for any sucess scenario
+    Scenario: Common validations for any success scenario
         Given a valid phone number identified by the token or provided in the request body
         When the request "retrieveDeviceSwapDate" is sent
         Then the response status code is 200
@@ -28,7 +28,7 @@ Feature: CAMARA Device Swap API, 0.2.0 - Operation retrieveDeviceSwapDate
     # Scenarios testing specific situations
 
     @retrieve_device_swap_date_2_valid_device_swap
-    Scenario: Retrieve decive swap date for a valid device swap
+    Scenario: Retrieve device swap date for a valid device swap
         Given a valid phone number identified by the token or provided in the request body
         And the device has been swapped
         When the request "retrieveDeviceSwapDate" is sent
@@ -64,7 +64,7 @@ Feature: CAMARA Device Swap API, 0.2.0 - Operation retrieveDeviceSwapDate
         When the HTTP "POST" request is sent
         Then the response status code is 422
         And the response property "$.status" is 422
-        And the response property "$.code" is "NOT_SUPPORTED"
+        And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
         And the response property "$.message" contains a user friendly text
 
     # Test cases related to the device identifier


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug
* correction
* tests


#### What this PR does / why we need it:
Fixes a wrong error code in test plan scenarios:

- Test @check_device_swap_8_NoDeviceSwapPhoneNumberNeverConnected -> Indicates 422 NOT_SUPPORTED.
- Test @retrieve_device_swap_date_5_not_activated -> Indicates 422 NOT_SUPPORTED.

Both scenarios need to reflect **SERVICE_NOT_APPLICABLE** instead.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #84 