### PR TITLE
Prepare maintenance release r2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,51 @@
 
 ## Table of Contents
 
-- **[r2.2](#r22)**
+- **[r2.3](#r23)**
+- [r2.2](#r22)
 - [r2.1](#r21)
 - **[r1.2](#r12)**
 - [r1.1](#r11)
 
 **Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
+
+# r2.3
+## Release Notes
+
+This public release contains the definition and documentation of
+* device-swap v0.2.0
+
+The API definition(s) are based on
+* Commonalities v0.5.0
+* Identity and Consent Management v0.3.0
+
+## device-swap v0.2.0
+
+**device-swap v0.2.0 is the public release of the Device Swap API**
+
+- 0.2.0 Device Swap API definition **with inline documentation**:
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceSwap/blob/r2.3/code/API_definitions/device-swap.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceSwap/r2.3/code/API_definitions/device-swap.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceSwap/r2.3/code/API_definitions/device-swap.yaml)
+
+Changes included in v0.2.0 in r2.3 compared to r2.2:
+### Added
+N/A
+
+### Changed
+N/A
+
+### Fixed
+
+* fix scenario error code and typos by @fernandopradocabrillo in https://github.com/camaraproject/DeviceSwap/pull/87
+
+### Removed
+N/A
+
+## New Contributors
+N/A
+
+**Full Changelog**: https://github.com/camaraproject/DeviceSwap/compare/r2.2...r2.3
 
 # r2.2
 ## Release Notes

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Repository to describe, develop, document and test the Device Swap APIs
 
 ## Release Information
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
-* The public release r2.2 contains the version 0.2.0 of the Device Swap API. The release tag is [r2.2](https://github.com/camaraproject/DeviceSwap/tree/r2.2).
+* The public release r2.3 contains the version 0.2.0 of the Device Swap API. The release tag is [r2.3](https://github.com/camaraproject/DeviceSwap/tree/r2.3).
 - 0.2.0 Device Swap API definition **with inline documentation**:
-  - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceSwap/blob/r2.2/code/API_definitions/device-swap.yaml)
-  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceSwap/r2.2/code/API_definitions/device-swap.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceSwap/r2.2/code/API_definitions/device-swap.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceSwap/blob/r2.3/code/API_definitions/device-swap.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceSwap/r2.3/code/API_definitions/device-swap.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceSwap/r2.3/code/API_definitions/device-swap.yaml)
 * The latest public release is available here: https://github.com/camaraproject/DeviceSwap/releases/latest
 * Other releases of this sub project are available in https://github.com/camaraproject/DeviceSwap/releases
 * For changes see [CHANGELOG.md](https://github.com/camaraproject/DeviceSwap/blob/main/CHANGELOG.md)

--- a/documentation/API_documentation/device-swap-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/device-swap-API-Readiness-Checklist.md
@@ -1,6 +1,6 @@
 # API Readiness Checklist
 
-Checklist for device-swap 0.2.0 in r2.2
+Checklist for device-swap 0.2.0 in r2.3
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information  |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|


### PR DESCRIPTION
Update CHANGELOG.md, README.md and API Readiness Checklist to reflect the new maintenance release tag r2.3, which fixes test scenario error codes and typos compared to r2.2.

#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

Prepares the maintenance release r2.3 by updating all release version references from r2.2 to r2.3. The API definition (device-swap v0.2.0) is unchanged; this release contains only test definition fixes introduced in PR #87.

#### Which issue(s) this PR fixes:

Fixes #84

#### Special notes for reviewers:

The API YAML spec is not modified. The only functional changes in this release line are in the test feature files (already merged via PR #87): error code `NOT_SUPPORTED` corrected to `SERVICE_NOT_APPLICABLE` and several typos fixed in scenario descriptions.

#### Changelog input

