### PR TITLE
fix: use headers ref for x-correlator in response 200 headers

### DIFF
--- a/code/API_definitions/device-swap.yaml
+++ b/code/API_definitions/device-swap.yaml
@@ -124,7 +124,7 @@ paths:
           description: Contains information about Device swap change
           headers:
             x-correlator:
-              $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -178,7 +178,7 @@ paths:
           description: Returns whether a device swap has been performed during a past period
           headers:
             x-correlator:
-              $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
           content:
             application/json:
               schema:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:
Replace `components/parameters/x-correlator` with`components/headers/x-correlator` in the response 200 headers of both /retrieve-date and /check operations.

The parameter ref inlines `name` and `in` fields during snapshot creation, which are not valid in a Header Object and cause S-209 OAS 3.x schema validation errors.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #98 

#### Changelog input

```
 release-note
fix - Use correct header ref for x-correlator in response 200 headers of /retrieve-date and /check operations
```